### PR TITLE
Added Hunger Timer

### DIFF
--- a/Assets/Art/MinifolksVillagers/Outline/FlippedMiniOldWoman.png.meta
+++ b/Assets/Art/MinifolksVillagers/Outline/FlippedMiniOldWoman.png.meta
@@ -585,8 +585,8 @@ TextureImporter:
       FlippedMiniOldWoman_33: 539495591
       FlippedMiniOldWoman_4: -1904692880
       FlippedMiniOldWoman_16: -342622146
-      FlippedMiniOldWoman_15: 250197237
       FlippedMiniOldWoman_39: 1426909096
+      FlippedMiniOldWoman_15: 250197237
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/Assets/Prefabs/Pawn2.prefab
+++ b/Assets/Prefabs/Pawn2.prefab
@@ -1,0 +1,281 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7127700996087011795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7127700996087011812}
+  - component: {fileID: 7127700996087011813}
+  - component: {fileID: 7127700996087011818}
+  - component: {fileID: 7127700996087011819}
+  - component: {fileID: 7127700996087011816}
+  - component: {fileID: 7127700996087011817}
+  - component: {fileID: 7127700996087011822}
+  - component: {fileID: 7127700996087011823}
+  - component: {fileID: 7127700996087011820}
+  - component: {fileID: 7127700996087011821}
+  - component: {fileID: 7127700996087011815}
+  m_Layer: 6
+  m_Name: Pawn2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7127700996087011812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.92, y: -0.17, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7127700996087011813
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 297621699, guid: 34990163db10e2340992b93b48007373, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &7127700996087011818
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: c1a97e33079a6814fb739a414579a46e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+--- !u!114 &7127700996087011819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 094eb60082ec8db47990ef41a8427710, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  anim: {fileID: 7127700996087011818}
+--- !u!114 &7127700996087011816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2a291976bd6fac4b91b64af176d6ae9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  myState: 0
+--- !u!50 &7127700996087011817
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!61 &7127700996087011822
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.0036964417, y: -0.31234503}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 0.16, y: 0.16}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.5046835, y: 0.14613342}
+  m_EdgeRadius: 0
+--- !u!61 &7127700996087011823
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 0.16, y: 0.16}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.54, y: 0.69}
+  m_EdgeRadius: 0
+--- !u!114 &7127700996087011820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11ca3f80e481e304baa48c4fe23e2ac3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 1.5
+  bounds: {fileID: 0}
+  minMoveTime: 2
+  maxMoveTime: 4
+  minWaitTime: 1
+  maxWaitTime: 3
+--- !u!114 &7127700996087011821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d97722ec54ca824d96483d69c4b93aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  npc: {fileID: 7127700996087011815}
+--- !u!114 &7127700996087011815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7127700996087011795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aa35d2b20157064f8b6dbb1b6e8a472, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  id: 
+  currentLocation: {fileID: 0}
+  damagedAnimationDuration: 1
+  deathAnimationDuration: 1
+  immuneFrameDuration: 2
+  timeBetweenFlashes: 0.5
+  flashColor: {r: 0, g: 0, b: 0, a: 0}
+  stats:
+    guid: 
+    x: 0
+    y: 0
+    z: 0
+    isDownward: 0
+    currentHealth: 0
+    maxHealth: 0
+    Inventory:
+    - Name: Special Item
+      IsConsumable: 0
+      Rarity: 4
+      Value: 420
+      Quantity: 1
+      BlockName: 
+  refuseLaborOrders: 0
+  hunger: 100

--- a/Assets/Prefabs/Pawn2.prefab.meta
+++ b/Assets/Prefabs/Pawn2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4d8e5e2f5fb89244bda99fe34798f12
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ConnorLaborOrder.unity
+++ b/Assets/Scenes/ConnorLaborOrder.unity
@@ -149,7 +149,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 489197899}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8bf8507690fa99e4fac6baac8d93e055, type: 3}
+  m_Script: {fileID: 11500000, guid: c7fdda20793d70f4885a961fc5d924ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   pawn_prefab: {fileID: 1110198859314352592, guid: 92a0f81592b4a3f4fade2bfd01abaa40, type: 3}
@@ -211,6 +211,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1449975288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1449975290}
+  - component: {fileID: 1449975289}
+  m_Layer: 0
+  m_Name: HungerTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1449975289
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449975288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2735e1a2e7e3ed24c8c190786de3852a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1449975290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449975288}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.575884, y: -24.471798, z: -9.772318}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1565520004
 GameObject:

--- a/Assets/Scriptable Objects/Entities/Pawn.asset
+++ b/Assets/Scriptable Objects/Entities/Pawn.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9288d5e23700e73448be1961652241bf, type: 3}
   m_Name: Pawn
   m_EditorClassIdentifier: 
-  entityName: pawn2
-  displayName: Pawn2
-  prefab: {fileID: 7127700996087011795, guid: c4d8e5e2f5fb89244bda99fe34798f12, type: 3}
+  entityName: pawn
+  displayName: Pawn
+  prefab: {fileID: 1110198859314352592, guid: 92a0f81592b4a3f4fade2bfd01abaa40, type: 3}

--- a/Assets/Scriptable Objects/Entities/Pawn2.asset
+++ b/Assets/Scriptable Objects/Entities/Pawn2.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9288d5e23700e73448be1961652241bf, type: 3}
-  m_Name: Pawn
+  m_Name: Pawn2
   m_EditorClassIdentifier: 
   entityName: pawn2
   displayName: Pawn2

--- a/Assets/Scriptable Objects/Entities/Pawn2.asset.meta
+++ b/Assets/Scriptable Objects/Entities/Pawn2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c4f5f8cafb882741a7c1dd390c01928
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scriptable Objects/PrefabList.asset
+++ b/Assets/Scriptable Objects/PrefabList.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4c6c6e00fdd1c784a87bb76dff142190, type: 2}
   - {fileID: 11400000, guid: 162d2f62a72a55b4c892de114744279b, type: 2}
   - {fileID: 11400000, guid: 9bd87b3077fd90b45a89078d3754e3fd, type: 2}
+  - {fileID: 11400000, guid: 3c4f5f8cafb882741a7c1dd390c01928, type: 2}

--- a/Assets/Scripts/GameManagers/LaborOrderManager.cs
+++ b/Assets/Scripts/GameManagers/LaborOrderManager.cs
@@ -45,18 +45,34 @@ public class LaborOrderManager : MonoBehaviour
     }
 
     // Method to add a pawn to the queue of available pawns
-    public static void addPawn(Pawn pawn)
+    // Return true if successful
+    public static bool addPawn(Pawn pawn)
     {
         // add pawn to the queue
-        availablePawns.Enqueue(pawn);
+        if (!pawn.refuseLaborOrders)
+        {
+            availablePawns.Enqueue(pawn);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+        // Method to remove a specific pawn from the availablePawns queue
+        public static void removeSpecificPawn(Pawn pawn)
+    {
+        // removes the pawn from the queue
+        Queue<Pawn> newQueue = new Queue<Pawn>(availablePawns.Where(p => p != pawn));
+        availablePawns = newQueue;
     }
 
     // Method to get an available pawn from the queue
     public static Pawn getAvailablePawn()
     {
         // return pawn from the queue
-        Pawn pawn = availablePawns.Dequeue();
-        return pawn;
+        return availablePawns.Dequeue();
     }
 
     // Method to add a labor task to the appropriate queue
@@ -83,6 +99,7 @@ public class LaborOrderManager : MonoBehaviour
         while(availablePawns.Count > 0 && getNumOfLaborOrders() > 0){
             
             Pawn pawn = getAvailablePawn();
+
             List<LaborType>[] laborTypePriority = pawn.getLaborTypePriority();
             bool found = false;
 

--- a/Assets/Scripts/GameManagers/LaborOrderManager.cs
+++ b/Assets/Scripts/GameManagers/LaborOrderManager.cs
@@ -60,11 +60,19 @@ public class LaborOrderManager : MonoBehaviour
         }
     }
 
-        // Method to remove a specific pawn from the availablePawns queue
-        public static void removeSpecificPawn(Pawn pawn)
+    // Method to find and remove a specific pawn from the availablePawns queue
+    public static void removeSpecificPawn(Pawn pawn)
     {
         // removes the pawn from the queue
-        Queue<Pawn> newQueue = new Queue<Pawn>(availablePawns.Where(p => p != pawn));
+        Queue<Pawn> newQueue = new Queue<Pawn>();
+        while(availablePawns.Count != 0)
+        {
+            Pawn queuedPawn = availablePawns.Dequeue();
+            if(queuedPawn != pawn)
+            {
+                newQueue.Enqueue(queuedPawn);
+            }
+        }
         availablePawns = newQueue;
     }
 

--- a/Assets/Scripts/LaborOrders/LaborOrder_Woodcut.cs
+++ b/Assets/Scripts/LaborOrders/LaborOrder_Woodcut.cs
@@ -32,7 +32,7 @@ public class LaborOrder_Woodcut : LaborOrder
             // cut down tree
             yield return new WaitForSeconds(getTimeToComplete());
 
-            if(targetTree != null)
+            if (targetTree != null)
             {
                 // delete tree
                 Vector3 treePosition = targetTree.transform.position;
@@ -43,10 +43,10 @@ public class LaborOrder_Woodcut : LaborOrder
                 GameObject woodObject = GlobalInstance.Instance.entityDictionary.InstantiateEntity("wood", "", treePosition);
                 woodObject.transform.SetParent(treeParent);
             }
+        } 
+        else
+        {
+            yield break;
         }
-        // add the pawn back to the queue of available pawns
-        //LaborOrderManager.addPawn(assignedPawn); // needs updated
-
-        yield break;
     }
 }

--- a/Assets/Scripts/NPC/HungerTimer.cs
+++ b/Assets/Scripts/NPC/HungerTimer.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/*
+ *   This is a timer that frequently decrements
+ *   pawn hunger when added to the scene
+ *
+ *   Pawns die when hunger hits zero
+*/
+
+public class HungerTimer : MonoBehaviour
+{
+    private float FREQUENCY = 1f;
+    private int decrement = 1;
+    private float resumeDelay = 0f;
+    private float lastTick = 0f;
+
+    void Awake()
+    {
+        
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        InvokeRepeating("DecrementHunger", 0f, FREQUENCY);
+    }
+
+    // Pause the timer
+    public void Pause()
+    {
+        resumeDelay = FREQUENCY - Time.time + lastTick;
+        CancelInvoke("DecrementHunger");
+    }
+
+    // Resume the timer
+    public void Resume()
+    {
+        InvokeRepeating("DecrementHunger", resumeDelay, FREQUENCY);
+    }
+
+    // Decrement the hunger for all living pawns
+    public void DecrementHunger()
+    {
+        lastTick = Time.time;
+        for(int i=Pawn.PawnList.Count-1; i>=0; i--)
+        {
+            Pawn.PawnList[i].hunger -= decrement;
+            if(Pawn.PawnList[i].hunger <= 0)
+            {
+                Pawn.PawnList[i].hunger = 0;
+                Pawn.PawnList[i].Die("has starved to death.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NPC/HungerTimer.cs.meta
+++ b/Assets/Scripts/NPC/HungerTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2735e1a2e7e3ed24c8c190786de3852a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Pawn.cs
+++ b/Assets/Scripts/NPC/Pawn.cs
@@ -5,15 +5,17 @@ using UnityEngine;
 [ExecuteInEditMode]
 public class Pawn : BaseNPC
 {
-	[SerializeField]
-    private List<LaborType>[] LaborTypePriority;    // required for LaborOrderManager labor order assignment logic
-    private LaborOrder currentLaborOrder;           // set by LaborOrderManager
-    private bool isAssigned;         // set to true when the pawn is assigned to a labor order, set to false when the pawn completes the labor order, controls Update() logic
-    private bool isWorking;
-
+    [SerializeField]
+    private List<LaborType>[] LaborTypePriority;            // required for LaborOrderManager labor order assignment logic
+    private LaborOrder currentLaborOrder;                   // set by LaborOrderManager
+    private bool isAssigned;                                // set to true when the pawn is assigned to a labor order
     private string pawnName;
-
     private const int NUM_OF_PRIORITY_LEVELS = 4;
+    private Coroutine currentExecution;                     // holds a reference to labor order execute() coroutine
+
+    public static List<Pawn> PawnList = new List<Pawn>();   // a list of all living pawns
+    public bool refuseLaborOrders = false;                  // prevents this pawn from being assigned labor orders, redundant for now but may be useful later
+    public int hunger = 100;
 
     public void moveLaborTypeToPriorityLevel(LaborType laborType, int priorityLevel) { // take a labor type and move it to the X priority level
         
@@ -41,34 +43,50 @@ public class Pawn : BaseNPC
 
     // set the current labor order of the pawn and indicate that the pawn is assigned to a labor order
     public void setCurrentLaborOrder(LaborOrder laborOrder) {
-        if(!isWorking)
-        {
-            currentLaborOrder = laborOrder;
-            isAssigned = true;
-        }
+        currentLaborOrder = laborOrder;
+        isAssigned = true;
     }
 
     // get the current labor type priorities of the pawn
     public List<LaborType>[] getLaborTypePriority() {
         return LaborTypePriority;
     }
-
+    
     // coroutine to complete labor order by waiting for the time to complete
     private IEnumerator completeCurrentLaborOrder() {
         isAssigned = false;
-        isWorking = true;
 
         // wait the time to complete the labor order
-        yield return StartCoroutine(currentLaborOrder.execute());
+        currentExecution = StartCoroutine(currentLaborOrder.execute());
+        yield return currentExecution;
 
 
         // debug print the pawn name and the labor type and the labor number and time to complete
         //Debug.Log($"{pawnName,-10} completed {currentLaborOrder.getLaborType(),-10} {currentLaborOrder.getOrderNumber(),-10} in {currentLaborOrder.getTimeToComplete(),-5:F2} seconds");
 
+        // add the pawn back to the queue of available pawns
+        LaborOrderManager.addPawn(this); // needs updated
+    }
 
-        // stop the coroutine
-        isWorking = false;
-        StopCoroutine(completeCurrentLaborOrder());
+    // cancels the current labor order
+    public void cancelCurrentLaborOrder()
+    {
+        if(currentExecution != null)
+            StopCoroutine(currentExecution);
+    }
+
+    // kills the pawn. Cancels labor order and removes them from appropriate lists.
+    public override void Die() { Die("has died."); }
+    public void Die(string cause)
+    {
+        PawnList.Remove(this);
+        LaborOrderManager.removeSpecificPawn(this);
+        cancelCurrentLaborOrder();
+        refuseLaborOrders = true;
+        Debug.Log(getPawnName() + " " + cause);
+        //base.Die();
+        GlobalInstance.Instance.entityDictionary.DestroySaveableObject(this);
+        // maybe check if PawnList is empty to initiate the Game Lose here
     }
 
     // Start is called before the first frame update
@@ -93,14 +111,18 @@ public class Pawn : BaseNPC
         pawnName = "Pawn" + GetInstanceID();
         name = pawnName;
 
-        // initialize the default isWorking to false
+        // initialize the default isAssigned to false
         isAssigned = false;
+
+        // add this pawn to the pawn list
+        PawnList.Add(this);
+        LaborOrderManager.addPawn(this);
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (isAssigned && !isWorking)
+        if (isAssigned)
         {
             StartCoroutine(completeCurrentLaborOrder());
         }

--- a/Assets/Scripts/TileMapDemoScripts/MapManager.cs
+++ b/Assets/Scripts/TileMapDemoScripts/MapManager.cs
@@ -19,7 +19,7 @@ public class MapManager : MonoBehaviour
     {
         CreateGrid();
         CreateTileMap();
-        //InitializeTileMap();
+        InitializeTileMap();
         
         player = (Player)FindObjectOfType(typeof(Player));
         pathFinding = new PathFinding(tileMap);
@@ -27,7 +27,7 @@ public class MapManager : MonoBehaviour
 
     void Start()
     {
-        InitializeTrigMap(); // alternative to InitializeTileMap()
+        //InitializeTrigMap(); // alternative to InitializeTileMap()
     }
 
     void Update()
@@ -97,6 +97,7 @@ public class MapManager : MonoBehaviour
     }
 
     // Create random test map -- for connors testing
+    /*
     private void InitializeTrigMap()
     {
         GlobalInstance.Instance.prefabList.InitializePrefabDictionary();
@@ -175,7 +176,7 @@ public class MapManager : MonoBehaviour
             }
         }
 
-        /*Debug.Log("trees: " + treecount);
-        Debug.Log("orders: " + LaborOrderManager.getNumOfLaborOrders());*/
-    }
+        //Debug.Log("trees: " + treecount);
+        //Debug.Log("orders: " + LaborOrderManager.getNumOfLaborOrders());
+    }*/
 }

--- a/Assets/Scripts/TileMapDemoScripts/MapManager.cs
+++ b/Assets/Scripts/TileMapDemoScripts/MapManager.cs
@@ -19,7 +19,7 @@ public class MapManager : MonoBehaviour
     {
         CreateGrid();
         CreateTileMap();
-        InitializeTileMap();
+        //InitializeTileMap();
         
         player = (Player)FindObjectOfType(typeof(Player));
         pathFinding = new PathFinding(tileMap);
@@ -27,7 +27,7 @@ public class MapManager : MonoBehaviour
 
     void Start()
     {
-        //InitializeTrigMap(); // alternative to InitializeTileMap()
+        InitializeTrigMap(); // alternative to InitializeTileMap()
     }
 
     void Update()
@@ -96,7 +96,7 @@ public class MapManager : MonoBehaviour
 
     }
 
-    // Create random test map
+    // Create random test map -- for connors testing
     private void InitializeTrigMap()
     {
         GlobalInstance.Instance.prefabList.InitializePrefabDictionary();
@@ -153,12 +153,12 @@ public class MapManager : MonoBehaviour
                     {
                         GameObject tree = GlobalInstance.Instance.entityDictionary.InstantiateEntity("tree", "", new Vector3(x + 0.5f, y + 0.5f, 0f));
                         tree.transform.parent = grid.transform;
-                        //LaborOrderManager.addLaborOrder(new LaborOrder_Woodcut(tree)); // needs to be updated
+                        LaborOrderManager.addLaborOrder(new LaborOrder_Woodcut(tree)); // needs to be updated
                         treecount++;
                     }
                     else if (UnityEngine.Random.Range(0, 100) == 0)  // create pawn
                     {
-                        GameObject pawn = GlobalInstance.Instance.entityDictionary.InstantiateEntity("pawn", "", new Vector3(x + 0.5f, y + 0.5f, 0f));
+                        GameObject pawn = GlobalInstance.Instance.entityDictionary.InstantiateEntity("pawn2", "", new Vector3(x + 0.5f, y + 0.5f, 0f));
                         pawn.transform.parent = grid.transform;
                         //LaborOrderManager.addPawn(pawn.GetComponent<Pawn>()); // needs to be updated
                     }

--- a/Assets/Tests/EditMode/LaborOrderManager/LaborOrderManagerTest.cs
+++ b/Assets/Tests/EditMode/LaborOrderManager/LaborOrderManagerTest.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class LaborOrderManagerTests : LaborOrderManager
+    {
+        [Test]
+        public void removeSpecificPawnTest()
+        {
+            availablePawns = new Queue<Pawn>();
+            GameObject pawn1 = new GameObject();
+            GameObject pawn2 = new GameObject();
+            Pawn p1 = pawn1.AddComponent<Pawn>();
+            Pawn p2 = pawn2.AddComponent<Pawn>();
+
+            removeSpecificPawn(p1);
+
+            Assert.IsTrue(availablePawns.Count == 1);
+            Assert.IsTrue(availablePawns.Dequeue() == p2);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/LaborOrderManager/LaborOrderManagerTest.cs.meta
+++ b/Assets/Tests/EditMode/LaborOrderManager/LaborOrderManagerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22c0843b49340fc408645c501f58a09b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a HungerTimer that frequently decrements the hunger of all pawns when added to the scene. If a pawn hits zero, they die.

In LaborOrderManager added removeSpecificPawn() to remove a pawn from the availablePawns queue.

In Pawn added cancelCurrentLaborOrder() to stop the execute() coroutine. Added Die() that overrides BaseNPC Die() (though will later be called for the death animation) and cancels the labor order, removes the pawn from the lists, and deletes the pawn.

Includes test for removeSpecificPawn()