### PR TITLE
Tile Hover, Work Area Sizing, and Pawn Count

### DIFF
--- a/Assets/Scenes/Ben's Wonderland.unity
+++ b/Assets/Scenes/Ben's Wonderland.unity
@@ -821,6 +821,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 520152985}
+  - {fileID: 1025244092}
   m_Father: {fileID: 1714381095}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2474,6 +2475,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   inputManager: {fileID: 502225668}
+  laborOrderPanelManager: {fileID: 6601706405368040374}
 --- !u!4 &502225666
 Transform:
   m_ObjectHideFlags: 0
@@ -2503,6 +2505,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5dbcd7229d9b4e849b2a8647803bf80b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DragDropHint: {fileID: 1025244093}
   myColony: {fileID: 304779965}
 --- !u!114 &502225668
 MonoBehaviour:
@@ -4931,6 +4934,141 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1025244091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1025244092}
+  - component: {fileID: 1025244094}
+  - component: {fileID: 1025244093}
+  m_Layer: 5
+  m_Name: DragDropInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1025244092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025244091}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 126803987}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 722.99866, y: -425}
+  m_SizeDelta: {x: 437.7628, y: 37.941}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1025244093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025244091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Drag and Drop to create zone.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 324c2c2cf4cbd6d459e637974f31c51f, type: 2}
+  m_sharedMaterial: {fileID: 8144738812644844558, guid: 324c2c2cf4cbd6d459e637974f31c51f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 43.75
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1025244094
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025244091}
+  m_CullTransparentMesh: 1
 --- !u!1 &1055338627
 GameObject:
   m_ObjectHideFlags: 0
@@ -7799,6 +7937,7 @@ MonoBehaviour:
   zoneInfo: {fileID: 1224048545}
   zoneContent: {fileID: 1784188312}
   zoneInfoTile: {fileID: 1783988888052550963, guid: cce9ab2cd8f62ea40ba92fee215c72ed, type: 3}
+  pawnCount: {fileID: 971099235}
   resourceListContent: {fileID: 981732322}
   resourceListElement: {fileID: 3644226144971936719, guid: 2b7dcb36e895d6f47a7747b1e0cbc23f, type: 3}
 --- !u!114 &1714381098
@@ -10066,7 +10205,6 @@ MonoBehaviour:
   button_prefab: {fileID: 0}
   pawnText_prefab: {fileID: 0}
   LaborText_prefab: {fileID: 0}
-  content: {fileID: 0}
   laborTypeNames: []
 --- !u!222 &6601706405368040377
 CanvasRenderer:
@@ -10117,7 +10255,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &6601706405368040382
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10193,9 +10331,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -17, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &6601706405526271165
 MonoBehaviour:
@@ -10583,7 +10721,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scenes/Ben's Wonderland.unity
+++ b/Assets/Scenes/Ben's Wonderland.unity
@@ -822,6 +822,7 @@ RectTransform:
   m_Children:
   - {fileID: 520152985}
   - {fileID: 1025244092}
+  - {fileID: 526035396}
   m_Father: {fileID: 1714381095}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2507,6 +2508,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DragDropHint: {fileID: 1025244093}
   myColony: {fileID: 304779965}
+  hoverDuration: 2
+  previousMousePosition: {x: 0, y: 0, z: 0}
+  wiggleRoom: 0.5
+  tileInfo: {fileID: 526035397}
 --- !u!114 &502225668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2899,6 +2904,141 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 520152984}
+  m_CullTransparentMesh: 1
+--- !u!1 &526035395
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 526035396}
+  - component: {fileID: 526035398}
+  - component: {fileID: 526035397}
+  m_Layer: 5
+  m_Name: TileInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &526035396
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526035395}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 126803987}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -733.2174, y: -412.32602}
+  m_SizeDelta: {x: 419.3278, y: 63.289}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &526035397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526035395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Tile Type: SAND       Collision: False      Position: (50.50, 47.50, 0.00)                              '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 324c2c2cf4cbd6d459e637974f31c51f, type: 2}
+  m_sharedMaterial: {fileID: 8144738812644844558, guid: 324c2c2cf4cbd6d459e637974f31c51f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36.85
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &526035398
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526035395}
   m_CullTransparentMesh: 1
 --- !u!1 &555823317
 GameObject:
@@ -10876,7 +11016,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 6601706406400536460}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.5
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assets/Scripts/UI/ColonyInfoManager.cs
+++ b/Assets/Scripts/UI/ColonyInfoManager.cs
@@ -18,6 +18,8 @@ public class ColonyInfoManager : MonoBehaviour
 
     [SerializeField] private GameObject zoneInfoTile;
 
+    [SerializeField] private TextMeshProUGUI pawnCount;
+
     // Resource List Variables
     [SerializeField] private GameObject resourceListContent;
 
@@ -54,6 +56,7 @@ public class ColonyInfoManager : MonoBehaviour
     {
         zoneNumber.text = (myColony.GetNextZoneNumber() - 1).ToString();
         colonyName.text = myColony.GetColonyName();
+        pawnCount.text = LaborOrderManager_VM.GetPawnCount().ToString();
     }
 
     /////////////////////////////////////

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -27,24 +27,28 @@ public static class UIManager
             case 6:
             {
                 GameObject.Find("Canvas/Warnings/CancelHint").SetActive(true);
+                GameObject.Find("Canvas/Warnings/DragDropInfo").SetActive(true);
                 Cursor.SetCursor(farmCursor, hotSpot, cursorMode);
                 break;
             }
             case 7:
             {
                 GameObject.Find("Canvas/Warnings/CancelHint").SetActive(true);
+                GameObject.Find("Canvas/Warnings/DragDropInfo").SetActive(true);
                 Cursor.SetCursor(destroyCursor, hotSpot, cursorMode);
                 break;
             }
             case 8:
             {
                 GameObject.Find("Canvas/Warnings/CancelHint").SetActive(true);
+                GameObject.Find("Canvas/Warnings/DragDropInfo").SetActive(true);
                 Cursor.SetCursor(createCursor, hotSpot, cursorMode);
                 break;
             }
             default:
             {
                 GameObject.Find("Canvas/Warnings/CancelHint").SetActive(false);
+                GameObject.Find("Canvas/Warnings/DragDropInfo").SetActive(false);
                 Cursor.SetCursor(null, hotSpot, cursorMode);
                 break;
             }


### PR DESCRIPTION
Added feature where when a user hovers over a tile, info on that tile is shown (will need to update this once we incorporate whatever version of PlacedObjects). Also added a UI element to show the size of a Work Area when a user is drag and dropping it. Finally, hooked up LaborOrderManager's "PawnCount()" to the Colony Info UI so the correct pawn count is now shown.