### PR TITLE
Pawn Priority Hot and Test Re-Adding

### DIFF
--- a/Assets/Scenes/Test Scenes/ChestPlacementTesting.unity
+++ b/Assets/Scenes/Test Scenes/ChestPlacementTesting.unity
@@ -4184,9 +4184,9 @@ RectTransform:
   m_Father: {fileID: 1622636648}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 130.2229, y: -42.5648}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 142.4458, y: 45.9583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &383982927
@@ -4687,9 +4687,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 945, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &430240606
@@ -7876,9 +7876,9 @@ RectTransform:
   m_Father: {fileID: 1622636648}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 646.6603, y: -42.5648}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 142.4458, y: 45.9583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &782857791
@@ -8011,9 +8011,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 525, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &786972891
@@ -12683,9 +12683,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 735, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1220502129
@@ -15066,9 +15066,9 @@ RectTransform:
   m_Father: {fileID: 1622636648}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 818.8061, y: -42.5648}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 142.4458, y: 45.9583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1441301637
@@ -15583,9 +15583,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1155, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1476388995
@@ -17236,9 +17236,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 105, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1599116220
@@ -17699,9 +17699,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1365, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1634308548
@@ -18976,9 +18976,9 @@ RectTransform:
   m_Father: {fileID: 1622636648}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 474.5145, y: -42.5648}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 142.4458, y: 45.9583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1720219791
@@ -19239,9 +19239,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1575, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1727200626
@@ -20091,9 +20091,9 @@ RectTransform:
   m_Father: {fileID: 1622636648}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 302.3687, y: -42.5648}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 142.4458, y: 45.9583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1840405003
@@ -23449,9 +23449,9 @@ RectTransform:
   m_Father: {fileID: 742806293}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 315, y: -21.07295}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 42.1459}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2097971968

--- a/Assets/Scenes/Test Scenes/ChestPlacementTesting.unity.meta
+++ b/Assets/Scenes/Test Scenes/ChestPlacementTesting.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 491ca03d05240ae419c9c414c9a096ec
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/PanelManager.cs
+++ b/Assets/Scripts/UI/PanelManager.cs
@@ -14,10 +14,7 @@ public class PanelManager : MonoBehaviour
     [SerializeField] private ColonyInfoManager colonyInfoManager;
     [SerializeField] private GameObject laborOrderPanel;
 
-    private void Awake() 
-    {
-        laborOrderPanel.GetComponent<LaborOrderPanelManager>().InitializeLaborOrderPanel();
-    }
+    private bool initialized = false;
 
     public void ToggleLaborOrderPanel()
     {
@@ -28,6 +25,11 @@ public class PanelManager : MonoBehaviour
         else
         {
             laborOrderPanel.SetActive(true);
+            if(!initialized)
+            {
+                initialized = true;
+                laborOrderPanel.GetComponentsInChildren<LaborOrderPanelManager>()[0].InitializeLaborOrderPanel();
+            }
         }
     }
 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1aaeebedd81236542ac5f4ddac2a41a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe8377e38509d164a81857d9ce184541
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Tests/EditMode/EditMode.asmdef
@@ -1,0 +1,9 @@
+{
+    "name": "EditMode",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ]
+}

--- a/Assets/Tests/EditMode/EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2a8d7053265187045bfead4b89dec6d1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode.meta
+++ b/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c5b14051891179640b18d6afd49c4b2d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/ExamplePlayModeTests.cs
+++ b/Assets/Tests/PlayMode/ExamplePlayModeTests.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace Tests 
+{
+	public class ExamplePlayModeTest
+	{
+
+        // This LoadScene will be universal for all playmode tests
+		[OneTimeSetUp]
+		public void LoadScene()
+		{
+            // Will load scene by this name,
+            // NOTE: Scene needs to be added to the Build Settings
+			SceneManager.LoadScene("ChestPlacementTesting");
+		}
+
+        // These are the actual tests
+		[UnityTest]
+		public IEnumerator ColonyInfoPanelOpeningTest()
+		{
+            //Arrange
+            // Wait for a bit to allow the scene to load
+			yield return new WaitForSeconds(0.5f);
+
+            // This will grab the GameObject in the scene by the name of "TestCharacter"
+			GameObject canvas = GameObject.Find("Canvas");
+
+            // This format is needed if you wanted to grab a gameobject which is a child of another or many
+            GameObject colonyInfoButton = GameObject.Find("Canvas/ActionList/Scroll View/Viewport/Content/CardBackground (4)");
+
+            //Act
+            // This simulates a click on a gameObject
+            colonyInfoButton.GetComponent<Button>().onClick.Invoke();
+
+            GameObject colonyInfoPanel = GameObject.Find("Canvas/ColonyOverview");
+
+            //Assert
+			Assert.AreEqual(colonyInfoPanel.activeSelf, true);
+		}
+	}
+}

--- a/Assets/Tests/PlayMode/ExamplePlayModeTests.cs.meta
+++ b/Assets/Tests/PlayMode/ExamplePlayModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e03d8d81f7e18642a869e7695f83e25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,0 +1,6 @@
+{
+    "name": "PlayMode",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ]
+}

--- a/Assets/Tests/PlayMode/PlayMode.asmdef.meta
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dda6640b78e57ff489c1879d53aeaf49
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -35,4 +35,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Test Scenes/NPCDamageTesting.unity
     guid: 01bf406e15a2ced47b320c476d07b58b
+  - enabled: 1
+    path: Assets/Scenes/Test Scenes/ChestPlacementTesting.unity
+    guid: 491ca03d05240ae419c9c414c9a096ec
   m_configObjects: {}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -585,7 +585,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 1
+  selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1


### PR DESCRIPTION
Previously was error due to LaborOrderPanelManager being attached to the child of the component being searched. Also re-added the deleted Test folders and created a new PlayMode test as an example on how to make them.