### PR TITLE
COL 109 - Tests for Items

### DIFF
--- a/Assets/Scenes/Test Scenes/ItemTests.unity
+++ b/Assets/Scenes/Test Scenes/ItemTests.unity
@@ -1,0 +1,269 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 2055981802}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1471434564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1471434565}
+  - component: {fileID: 1471434566}
+  - component: {fileID: 1471434567}
+  m_Layer: 0
+  m_Name: Objects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1471434565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471434564}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1471434566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471434564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d53cad303ecb1dc41b3884f636994ae4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemName: Wood
+  location: {fileID: 0}
+  isGatherable: 1
+  isPlaceable: 1
+  isDeconstructable: 0
+  isWoodcuttable: 0
+  isMineable: 0
+  isForageable: 0
+  isCraftable: 0
+  isPlantcuttable: 0
+  isItemized: 0
+--- !u!114 &1471434567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471434564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7994319836976f94fa8cbd90bfb677c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemName: NullSpriteRenderer
+  location: {fileID: 0}
+  isGatherable: 0
+  isPlaceable: 0
+  isDeconstructable: 0
+  isWoodcuttable: 0
+  isMineable: 0
+  isForageable: 0
+  isCraftable: 0
+  isPlantcuttable: 0
+  isItemized: 0
+  resourceCountRef: 0
+  resourceCount: 0
+  spriteRenderer: {fileID: 0}
+--- !u!850595691 &2055981802
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 4
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 1
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 1
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 3
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 256
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 1
+  m_PVREnvironmentMIS: 1
+  m_PVRFilteringMode: 1
+  m_PVRDenoiserTypeDirect: 1
+  m_PVRDenoiserTypeIndirect: 1
+  m_PVRDenoiserTypeAO: 1
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0

--- a/Assets/Scenes/Test Scenes/ItemTests.unity.meta
+++ b/Assets/Scenes/Test Scenes/ItemTests.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ffe2f3322dfa69147b004a282383b96d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/ExamplePlayModeTests.cs
+++ b/Assets/Tests/PlayMode/ExamplePlayModeTests.cs
@@ -11,7 +11,7 @@ namespace Tests
 	{
 
         // This LoadScene will be universal for all playmode tests
-		[OneTimeSetUp]
+		[SetUp]
 		public void LoadScene()
 		{
             // Will load scene by this name,

--- a/Assets/Tests/PlayMode/ItemTest.cs
+++ b/Assets/Tests/PlayMode/ItemTest.cs
@@ -1,0 +1,227 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace Tests
+{
+    public class ItemTest
+    {
+        [SetUp]
+        public void LoadScene()
+        {
+            SceneManager.LoadScene("ItemTests");
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Awake()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            Item item = objs.AddComponent<Item>();
+            Berries berries = objs.AddComponent<Berries>();
+            Bush bush = objs.AddComponent<Bush>();
+            Rock rock = objs.AddComponent<Rock>();
+            RockCoin rockCoin = objs.AddComponent<RockCoin>();
+            Coin coin = objs.AddComponent<Coin>();
+            RockResource rockResource = objs.AddComponent<RockResource>();
+            RockWall rockWall = objs.AddComponent<RockWall>();
+            Tree tree = objs.AddComponent<Tree>();
+            Wheat wheat = objs.AddComponent<Wheat>();
+            WheatItem wheatItem = objs.AddComponent<WheatItem>();
+            Wood wood = objs.AddComponent<Wood>();
+            WoodWall woodWall = objs.AddComponent<WoodWall>();
+            StairsItem stairsItem = objs.AddComponent<StairsItem>();
+            ErrorObject errorObject = objs.AddComponent<ErrorObject>();
+
+            Assert.IsNotNull(item);
+            Assert.IsNotNull(berries);
+            Assert.IsNotNull(bush);
+            Assert.IsNotNull(rock);
+            Assert.IsNotNull(rockCoin);
+            Assert.IsNotNull(coin);
+            Assert.IsNotNull(rockResource);
+            Assert.IsNotNull(rockWall);
+            Assert.IsNotNull(tree);
+            Assert.IsNotNull(wheat);
+            Assert.IsNotNull(wheatItem);
+            Assert.IsNotNull(wood);
+            Assert.IsNotNull(woodWall);
+            Assert.IsNotNull(stairsItem);
+            Assert.IsNotNull(errorObject);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Bush_IncrementAllResources()
+        {
+            yield return new WaitForSeconds(0.5f);
+            
+            GameObject objs = GameObject.Find("Objects");
+            Bush itemizedBush = objs.AddComponent<Bush>();
+            Bush itemizedBush2 = objs.AddComponent<Bush>();
+            Bush itemizedBush3 = objs.AddComponent<Bush>();
+            Bush nullSpriteRendererBush = objs.AddComponent<Bush>();
+            Bush nonNullSpriteRendererBush = objs.AddComponent<Bush>();
+            Bush fullResourceBush = objs.AddComponent<Bush>();
+
+            itemizedBush.isItemized = true;
+            itemizedBush2.isItemized = false;
+            itemizedBush3.isItemized = false;
+            Bush.plantResources.Add(itemizedBush2);
+            Bush.plantResources.Add(itemizedBush);
+            Bush.plantResources.Add(itemizedBush3);
+            Bush.plantResources[1].isItemized = true;
+            Bush.plantResources[2].isItemized = false;
+            Bush.IncrementAllResources(1);
+            Bush.plantResources.Clear();
+
+            nullSpriteRendererBush.isItemized = false;
+            nullSpriteRendererBush.spriteRenderer = null;
+            Bush.plantResources.Add(nullSpriteRendererBush);
+            Bush.IncrementAllResources(1);
+            Bush.plantResources.Clear();
+
+            objs.AddComponent<SpriteRenderer>();
+            nonNullSpriteRendererBush.isItemized = false;
+            nonNullSpriteRendererBush.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            nonNullSpriteRendererBush.resourceCount = 1;
+            Bush.plantResources.Add(nonNullSpriteRendererBush);
+            Bush.IncrementAllResources(1);
+            Bush.plantResources.Clear();
+
+            fullResourceBush.isItemized = false;
+            fullResourceBush.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            fullResourceBush.resourceCount = 24;
+            Bush.plantResources.Add(fullResourceBush);
+            Bush.IncrementAllResources(50);
+            Bush.plantResources.Clear();
+
+            Assert.IsNotNull(itemizedBush);
+            Assert.IsNotNull(nullSpriteRendererBush);
+            Assert.IsNotNull(nonNullSpriteRendererBush);
+            Assert.IsNotNull(fullResourceBush);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Bush_Deconstruct()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            Bush.plantResources.Clear();
+            Bush bush = objs.AddComponent<Bush>();
+
+            bush.Deconstruct();
+
+            Assert.AreEqual(Bush.plantResources.Count, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Bush_Harvest()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            objs.AddComponent<SpriteRenderer>();
+            Bush bush = objs.AddComponent<Bush>();
+            bush.resourceCount = 25;
+
+            int val = bush.Harvest();
+            Assert.AreEqual(val, 25);
+
+            Bush bush2 = objs.AddComponent<Bush>();
+            bush2.resourceCount = 1;
+
+            int val2 = bush2.Harvest();
+            Assert.AreEqual(val2, 1);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Wheat_IncrementAllResources()
+        {
+            yield return new WaitForSeconds(0.5f);
+            
+            GameObject objs = GameObject.Find("Objects");
+            Wheat itemizedWheat = objs.AddComponent<Wheat>();
+            Wheat itemizedWheat2 = objs.AddComponent<Wheat>();
+            Wheat itemizedWheat3 = objs.AddComponent<Wheat>();
+            Wheat nullSpriteRendererWheat = objs.AddComponent<Wheat>();
+            Wheat nonNullSpriteRendererWheat = objs.AddComponent<Wheat>();
+            Wheat fullResourceWheat = objs.AddComponent<Wheat>();
+
+            itemizedWheat.isItemized = true;
+            itemizedWheat2.isItemized = false;
+            itemizedWheat3.isItemized = false;
+            Wheat.plantResources.Add(itemizedWheat2);
+            Wheat.plantResources.Add(itemizedWheat);
+            Wheat.plantResources.Add(itemizedWheat3);
+            Wheat.plantResources[1].isItemized = true;
+            Wheat.plantResources[2].isItemized = false;
+            Wheat.IncrementAllResources(1);
+            Wheat.plantResources.Clear();
+
+            nullSpriteRendererWheat.isItemized = false;
+            nullSpriteRendererWheat.spriteRenderer = null;
+            Wheat.plantResources.Add(nullSpriteRendererWheat);
+            Wheat.IncrementAllResources(1);
+            Wheat.plantResources.Clear();
+
+            objs.AddComponent<SpriteRenderer>();
+            nonNullSpriteRendererWheat.isItemized = false;
+            nonNullSpriteRendererWheat.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            nonNullSpriteRendererWheat.resourceCount = 1;
+            Wheat.plantResources.Add(nonNullSpriteRendererWheat);
+            Wheat.IncrementAllResources(1);
+            Wheat.plantResources.Clear();
+
+            fullResourceWheat.isItemized = false;
+            fullResourceWheat.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            fullResourceWheat.resourceCount = 24;
+            Wheat.plantResources.Add(fullResourceWheat);
+            Wheat.IncrementAllResources(50);
+            Wheat.plantResources.Clear();
+
+            Assert.IsNotNull(itemizedWheat);
+            Assert.IsNotNull(nullSpriteRendererWheat);
+            Assert.IsNotNull(nonNullSpriteRendererWheat);
+            Assert.IsNotNull(fullResourceWheat);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Wheat_Deconstruct()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            Wheat.plantResources.Clear();
+            Wheat wheat = objs.AddComponent<Wheat>();
+
+            wheat.Deconstruct();
+
+            Assert.AreEqual(Wheat.plantResources.Count, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Wheat_Harvest()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            objs.AddComponent<SpriteRenderer>();
+            Wheat wheat = objs.AddComponent<Wheat>();
+            wheat.resourceCount = 25;
+
+            int val = wheat.Harvest();
+            Assert.AreEqual(val, 25);
+
+            Wheat wheat2 = objs.AddComponent<Wheat>();
+            wheat2.resourceCount = 1;
+
+            int val2 = wheat2.Harvest();
+            Assert.AreEqual(val2, 1);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ItemTest.cs
+++ b/Assets/Tests/PlayMode/ItemTest.cs
@@ -223,5 +223,89 @@ namespace Tests
             int val2 = wheat2.Harvest();
             Assert.AreEqual(val2, 1);
         }
+        [UnityTest]
+        public IEnumerator Item_Tree_IncrementAllResources()
+        {
+            yield return new WaitForSeconds(0.5f);
+            
+            GameObject objs = GameObject.Find("Objects");
+            Tree itemizedTree = objs.AddComponent<Tree>();
+            Tree itemizedTree2 = objs.AddComponent<Tree>();
+            Tree itemizedTree3 = objs.AddComponent<Tree>();
+            Tree nullSpriteRendererTree = objs.AddComponent<Tree>();
+            Tree nonNullSpriteRendererTree = objs.AddComponent<Tree>();
+            Tree fullResourceTree = objs.AddComponent<Tree>();
+
+            itemizedTree.isItemized = true;
+            itemizedTree2.isItemized = false;
+            itemizedTree3.isItemized = false;
+            Tree.plantResources.Add(itemizedTree2);
+            Tree.plantResources.Add(itemizedTree);
+            Tree.plantResources.Add(itemizedTree3);
+            Tree.plantResources[1].isItemized = true;
+            Tree.plantResources[2].isItemized = false;
+            Tree.IncrementAllResources(1);
+            Tree.plantResources.Clear();
+
+            nullSpriteRendererTree.isItemized = false;
+            nullSpriteRendererTree.spriteRenderer = null;
+            Tree.plantResources.Add(nullSpriteRendererTree);
+            Tree.IncrementAllResources(1);
+            Tree.plantResources.Clear();
+
+            objs.AddComponent<SpriteRenderer>();
+            nonNullSpriteRendererTree.isItemized = false;
+            nonNullSpriteRendererTree.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            nonNullSpriteRendererTree.resourceCount = 1;
+            Tree.plantResources.Add(nonNullSpriteRendererTree);
+            Tree.IncrementAllResources(1);
+            Tree.plantResources.Clear();
+
+            fullResourceTree.isItemized = false;
+            fullResourceTree.spriteRenderer = objs.GetComponent<SpriteRenderer>() as SpriteRenderer;
+            fullResourceTree.resourceCount = 24;
+            Tree.plantResources.Add(fullResourceTree);
+            Tree.IncrementAllResources(50);
+            Tree.plantResources.Clear();
+
+            Assert.IsNotNull(itemizedTree);
+            Assert.IsNotNull(nullSpriteRendererTree);
+            Assert.IsNotNull(nonNullSpriteRendererTree);
+            Assert.IsNotNull(fullResourceTree);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Tree_Deconstruct()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            Tree.plantResources.Clear();
+            Tree tree = objs.AddComponent<Tree>();
+
+            tree.Deconstruct();
+
+            Assert.AreEqual(Tree.plantResources.Count, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator Item_Tree_Harvest()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            GameObject objs = GameObject.Find("Objects");
+            objs.AddComponent<SpriteRenderer>();
+            Tree Tree = objs.AddComponent<Tree>();
+            Tree.resourceCount = 25;
+
+            int val = Tree.Harvest();
+            Assert.AreEqual(val, 25);
+
+            Tree tree2 = objs.AddComponent<Tree>();
+            tree2.resourceCount = 1;
+
+            int val2 = tree2.Harvest();
+            Assert.AreEqual(val2, 1);
+        }
     }
 }

--- a/Assets/Tests/PlayMode/ItemTest.cs.meta
+++ b/Assets/Tests/PlayMode/ItemTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49bbd70e763e1cc4cafdef7c394506c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,5 +1,8 @@
 {
     "name": "PlayMode",
+    "references": [
+        "Scripts"
+    ],
     "optionalUnityReferences": [
         "TestAssemblies"
     ]

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -38,4 +38,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Test Scenes/ChestPlacementTesting.unity
     guid: 491ca03d05240ae419c9c414c9a096ec
+  - enabled: 1
+    path: Assets/Scenes/Test Scenes/ItemTests.unity
+    guid: ffe2f3322dfa69147b004a282383b96d
   m_configObjects: {}


### PR DESCRIPTION
Made a bunch of tests for items and classes that inherit from item

### Changes made
---
- **ExamplePlayModeTests.cs**
  - Changed `OneTimeSetUp` to `SetUp`
- **ItemTest.cs**
  - A bunch of simple tests were added that just made sure these items could load and all that.
  - `Bush`, `Tree`, and `Wheat` had their extra methods tested as well
- **PlayMode.asmdef**
  - Added reference to Scripts for testing purposes
---
![image](https://user-images.githubusercontent.com/65436229/235038796-e02bfd48-091b-4e2d-aa39-bb22af0a7f4e.png)
